### PR TITLE
typos and anchored positions

### DIFF
--- a/2022/talks.md
+++ b/2022/talks.md
@@ -51,7 +51,7 @@ Talks are 20 minutes long, including 5 minutes allocated for questions from the 
 
 ## Late-morning Section
 
-**Chair:** Samual Isaacson
+**Chair:** Samuel Isaacson
 
 {{anchor keynote}}
 * **Keynote**
@@ -79,7 +79,7 @@ Talks are 20 minutes long, including 5 minutes allocated for questions from the 
     *Time:* 12:20PM - 12:40PM
 
     *Speaker:* Shashi Gowda
- 
+
     *Abstract:* In this talk, I will review previous work on expressing array operations in code and the manipulation of that code itself. I will consider trade-offs between loop-based programming and vectorized array operations (as in MATLAB), then explore newer developments in packages like JAX, Dex, XLA, and finally in Julia's Symbolics package. We explore how symbolic array operations with relevant metadata allows for optimization opportunities which are unavailable in straight-forward code.
 
 {{anchor structuralid}}

--- a/_css/style.css
+++ b/_css/style.css
@@ -9,6 +9,13 @@ a {
     color: #9d253d;
 }
 
+a.anchor {
+    display: block;
+    position: relative;
+    top: -70px;
+    visibility: hidden;
+}
+
 table {
     line-height: 1em;
     margin-left: auto;

--- a/utils.jl
+++ b/utils.jl
@@ -74,5 +74,5 @@ end
 end
 
 function hfun_anchor(id)
-    return """<a id=\"$(id[1])\"></a>"""
+    return """<a id=\"$(id[1])\" class=\"anchor\"></a>"""
 end


### PR DESCRIPTION
fix italic emphasis of one of the "Abstract"
fix name of one of the chairs
adjust the position of the anchored text in talks, which is currently hidden by the nav bar